### PR TITLE
feat!: Update to vscode 1.87.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
-    "@tsconfig/node16": "^16.1.1",
+    "@tsconfig/node18": "^18.2.2",
     "@types/node": "^18.19.2",
-    "@types/vscode": "^1.86.0",
+    "@types/vscode": "^1.87.0",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.13.1",
     "eslint": "^8.55.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@jest/globals": "^29.7.0",
     "@tsconfig/node16": "^16.1.1",
     "@types/node": "^18.19.2",
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "^1.86.0",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.13.1",
     "eslint": "^8.55.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0
-      '@tsconfig/node16':
-        specifier: ^16.1.1
-        version: 16.1.1
+      '@tsconfig/node18':
+        specifier: ^18.2.2
+        version: 18.2.2
       '@types/node':
         specifier: ^18.19.2
         version: 18.19.2
       '@types/vscode':
-        specifier: ^1.86.0
+        specifier: ^1.87.0
         version: 1.87.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.13.1
@@ -1212,10 +1212,6 @@ packages:
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
     dependencies:
       '@sinonjs/commons': 3.0.0
-    dev: true
-
-  /@tsconfig/node16@16.1.1:
-    resolution: {integrity: sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==}
     dev: true
 
   /@tsconfig/node18@18.2.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^18.19.2
         version: 18.19.2
       '@types/vscode':
-        specifier: ^1.85.0
-        version: 1.85.0
+        specifier: ^1.86.0
+        version: 1.87.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.13.1
         version: 6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.55.0)(typescript@5.3.2)
@@ -1378,8 +1378,8 @@ packages:
     resolution: {integrity: sha512-LCe1FvCDMJKkPdLVGYhP0HRJ1PDop2gRVm/zFHiOKwYLBRS7vEV3uOOUId4HMV+L1IxqyS+IZXMmlSMRbZGIAw==}
     dev: true
 
-  /@types/vscode@1.85.0:
-    resolution: {integrity: sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==}
+  /@types/vscode@1.87.0:
+    resolution: {integrity: sha512-y3yYJV2esWr8LNjp3VNbSMWG7Y43jC8pCldG8YwiHGAQbsymkkMMt0aDT1xZIOFM2eFcNiUc+dJMx1+Z0UT8fg==}
     dev: true
 
   /@types/yargs-parser@21.0.3:

--- a/src/vscode/TabGroups.test.ts
+++ b/src/vscode/TabGroups.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, jest } from '@jest/globals';
 // eslint-disable-next-line node/no-missing-import
 import type { TabGroup } from 'vscode';
-import { MockTabGroups } from './TabGroups';
+import { createMockTabGroups } from './TabGroups';
 
 describe('TabGroups', () => {
     test('new MockTabGroups', () => {
@@ -11,7 +11,7 @@ describe('TabGroups', () => {
             activeTab: undefined,
             tabs: [],
         };
-        const mtg = new MockTabGroups(jest, [tg]);
+        const mtg = createMockTabGroups(jest, [tg]);
         expect(mtg.activeTabGroup).toBe(tg);
     });
 });

--- a/src/vscode/TabGroups.ts
+++ b/src/vscode/TabGroups.ts
@@ -2,17 +2,20 @@
 import type { TabGroups, TabGroup } from 'vscode';
 import { TestFramework } from '../TestFramework';
 
-export class MockTabGroups implements TabGroups {
-    constructor(
-        private jest: TestFramework,
-        readonly all: TabGroup[],
-    ) {}
+export function createMockTabGroups(jest: TestFramework, all: TabGroup[]) {
+    class MockTabGroups implements TabGroups {
+        constructor(readonly all: TabGroup[]) {}
 
-    get activeTabGroup(): TabGroup {
-        return this.all[0];
+        get activeTabGroup(): TabGroup {
+            return this.all[0];
+        }
+
+        onDidChangeTabGroups = jest.fn();
+        onDidChangeTabs = jest.fn();
+        close = jest.fn();
     }
 
-    onDidChangeTabGroups = this.jest.fn();
-    onDidChangeTabs = this.jest.fn();
-    close = this.jest.fn();
+    return new MockTabGroups(all);
 }
+
+export type MockTabGroups = ReturnType<typeof createMockTabGroups>;

--- a/src/vscode/TextEditor.test.ts
+++ b/src/vscode/TextEditor.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test, jest } from '@jest/globals';
 
 import { createTextDocument } from '../vscodeTypesHelper';
-import { MockTextEditor } from './TextEditor';
+import { createMockTextEditor } from './TextEditor';
 import { Uri } from './uri';
 
 describe('TextEditor', () => {
     test('MockTextEditor', () => {
         const doc = createTextDocument(Uri.file(__filename), sampleContent());
-        const te = new MockTextEditor(jest, doc);
+        const te = createMockTextEditor(jest, doc);
         expect(te.document).toBe(doc);
         expect(te.selection).toBeDefined();
         expect(te.selections).toHaveLength(1);

--- a/src/vscode/TextEditor.ts
+++ b/src/vscode/TextEditor.ts
@@ -3,58 +3,68 @@ import type * as vscode from 'vscode';
 import * as mockedTypes from './extHostTypes';
 import { TestFramework } from '../TestFramework';
 
-export class MockTextEditor implements vscode.TextEditor {
-    _options: vscode.TextEditorOptions = {};
-    _visibleRanges: vscode.Range[] = [];
-    _selections: vscode.Selection[];
+export function createMockTextEditor(
+    jest: TestFramework,
+    document: vscode.TextDocument,
+    _viewColumn?: vscode.ViewColumn | undefined,
+    selection?: vscode.Selection,
+) {
+    class MockTextEditor implements vscode.TextEditor {
+        _options: vscode.TextEditorOptions = {};
+        _visibleRanges: vscode.Range[] = [];
+        _selections: vscode.Selection[];
 
-    constructor(
-        private jest: TestFramework,
-        public _document: vscode.TextDocument,
-        public _viewColumn?: vscode.ViewColumn | undefined,
-        selection: vscode.Selection = new mockedTypes.Selection(
-            new mockedTypes.Position(0, 0),
-            new mockedTypes.Position(0, 0),
-        ),
-    ) {
-        this._selections = [selection];
+        constructor(
+            public _document: vscode.TextDocument,
+            public _viewColumn?: vscode.ViewColumn | undefined,
+            selection: vscode.Selection = new mockedTypes.Selection(
+                new mockedTypes.Position(0, 0),
+                new mockedTypes.Position(0, 0),
+            ),
+        ) {
+            this._selections = [selection];
+        }
+
+        get document(): vscode.TextDocument {
+            return this._document;
+        }
+
+        /**
+         * The primary selection on this text editor. Shorthand for `TextEditor.selections[0]`.
+         */
+        get selection(): vscode.Selection {
+            return this.selections[0];
+        }
+
+        get selections(): vscode.Selection[] {
+            return this._selections;
+        }
+
+        get visibleRanges(): vscode.Range[] {
+            return this._visibleRanges;
+        }
+
+        get options(): vscode.TextEditorOptions {
+            return this._options;
+        }
+
+        set options(s: vscode.TextEditorOptions) {
+            this._options = s;
+        }
+
+        get viewColumn(): vscode.ViewColumn | undefined {
+            return this._viewColumn;
+        }
+
+        edit = jest.fn();
+        insertSnippet = jest.fn();
+        setDecorations = jest.fn();
+        revealRange = jest.fn();
+        show = jest.fn();
+        hide = jest.fn();
     }
 
-    get document(): vscode.TextDocument {
-        return this._document;
-    }
-
-    /**
-     * The primary selection on this text editor. Shorthand for `TextEditor.selections[0]`.
-     */
-    get selection(): vscode.Selection {
-        return this.selections[0];
-    }
-
-    get selections(): vscode.Selection[] {
-        return this._selections;
-    }
-
-    get visibleRanges(): vscode.Range[] {
-        return this._visibleRanges;
-    }
-
-    get options(): vscode.TextEditorOptions {
-        return this._options;
-    }
-
-    set options(s: vscode.TextEditorOptions) {
-        this._options = s;
-    }
-
-    get viewColumn(): vscode.ViewColumn | undefined {
-        return this._viewColumn;
-    }
-
-    edit = this.jest.fn();
-    insertSnippet = this.jest.fn();
-    setDecorations = this.jest.fn();
-    revealRange = this.jest.fn();
-    show = this.jest.fn();
-    hide = this.jest.fn();
+    return new MockTextEditor(document, _viewColumn, selection);
 }
+
+export type MockTextEditor = ReturnType<typeof createMockTextEditor>;

--- a/src/vscode/extHostTypes.ts
+++ b/src/vscode/extHostTypes.ts
@@ -1155,6 +1155,7 @@ export enum TextEditorLineNumbersStyle {
     Off = 0,
     On = 1,
     Relative = 2,
+    Interval = 3,
 }
 
 export enum TextDocumentSaveReason {

--- a/src/vscode/window.ts
+++ b/src/vscode/window.ts
@@ -3,9 +3,9 @@ import type { TextEditor, TextDocumentShowOptions, Uri, TextDocument, ViewColumn
 // eslint-disable-next-line node/no-missing-import, import/no-duplicates
 import type * as vscode from 'vscode';
 import { Selection } from './extHostTypes';
-import { MockTextEditor } from './TextEditor';
+import { createMockTextEditor } from './TextEditor';
 import { isUri } from './uri';
-import { MockTabGroups } from './TabGroups';
+import { createMockTabGroups } from './TabGroups';
 import { TestFramework } from '../TestFramework';
 import { Workspace } from './workspace';
 
@@ -34,7 +34,7 @@ export function createWindow(jest: TestFramework, workspace: Workspace): Window 
         visibleNotebookEditors: [],
         visibleTextEditors: [],
 
-        tabGroups: new MockTabGroups(jest, []),
+        tabGroups: createMockTabGroups(jest, []),
 
         // Fully mocked methods
         createStatusBarItem: jest.fn(createStatusBarItem),
@@ -145,6 +145,6 @@ export function createWindow(jest: TestFramework, workspace: Workspace): Window 
         const selectionRange = options?.selection;
         const selection = selectionRange && new Selection(selectionRange.start, selectionRange.start);
 
-        return new MockTextEditor(jest, document, viewColumn, selection);
+        return createMockTextEditor(jest, document, viewColumn, selection);
     }
 }

--- a/src/vscode/workspace.ts
+++ b/src/vscode/workspace.ts
@@ -8,80 +8,84 @@ import { TestFramework } from '../TestFramework';
 
 export type Workspace = typeof vscode.workspace;
 
-export class MockWorkspace implements Workspace {
-    constructor(private jest: TestFramework) {}
-    private _fs = createMockFileSystem(this.jest);
+export function createWorkspace(jest: TestFramework) {
+    const _fs = createMockFileSystem(jest);
+    let _workspaceFolders: Workspace['workspaceFolders'] = undefined;
 
-    private _workspaceFolders: Workspace['workspaceFolders'] = undefined;
+    class MockWorkspace implements Workspace {
+        constructor() {}
 
-    get workspaceFolders(): Workspace['workspaceFolders'] {
-        return this._workspaceFolders;
+        get workspaceFolders(): Workspace['workspaceFolders'] {
+            return _workspaceFolders;
+        }
+
+        setWorkspaceFolders(folders: vscode.WorkspaceFolder[] | undefined): void {
+            _workspaceFolders = folders;
+        }
+
+        get fs(): Workspace['fs'] {
+            return _fs;
+        }
+
+        get name(): Workspace['name'] {
+            return 'mock-workspace';
+        }
+
+        get workspaceFile(): Workspace['workspaceFile'] {
+            return undefined;
+        }
+
+        rootPath = undefined;
+        isTrusted = true;
+        textDocuments = [];
+        notebookDocuments = [];
+
+        __mockConfig = createMockWorkspaceConfiguration(jest);
+
+        applyEdit = jest.fn();
+        asRelativePath = jest.fn((a) => a?.toString());
+        createFileSystemWatcher = jest.fn();
+        findFiles = jest.fn();
+        getConfiguration = jest.fn((...args: Parameters<Workspace['getConfiguration']>) =>
+            this.__mockConfig.__getConfiguration(...args),
+        );
+        getWorkspaceFolder = jest.fn((uri) => getWorkspaceFolder(uri, this.workspaceFolders || []));
+        onDidSaveTextDocument = jest.fn();
+        openTextDocument = openTextDocument;
+        openNotebookDocument = jest.fn();
+        onDidChangeConfiguration = jest.fn();
+        onDidChangeNotebookDocument = jest.fn();
+        onDidChangeTextDocument = jest.fn();
+        onDidChangeWorkspaceFolders = jest.fn();
+        onDidCloseNotebookDocument = jest.fn();
+        onDidCloseTextDocument = jest.fn();
+        onDidCreateFiles = jest.fn();
+        onDidDeleteFiles = jest.fn();
+        onDidGrantWorkspaceTrust = jest.fn();
+        onDidOpenNotebookDocument = jest.fn();
+        onDidOpenTextDocument = jest.fn();
+        onDidRenameFiles = jest.fn();
+        onDidSaveNotebookDocument = jest.fn();
+        onWillCreateFiles = jest.fn();
+        onWillDeleteFiles = jest.fn();
+        onWillRenameFiles = jest.fn();
+        onWillSaveNotebookDocument = jest.fn();
+        onWillSaveTextDocument = jest.fn();
+        registerFileSystemProvider = jest.fn();
+        registerNotebookSerializer = jest.fn();
+        registerTaskProvider = jest.fn();
+        registerTextDocumentContentProvider = jest.fn();
+        saveAll = jest.fn();
+        save = jest.fn();
+        saveAs = jest.fn();
+        updateWorkspaceFolders = jest.fn();
     }
 
-    setWorkspaceFolders(folders: vscode.WorkspaceFolder[] | undefined): void {
-        this._workspaceFolders = folders;
-    }
-
-    get fs(): Workspace['fs'] {
-        return this._fs;
-    }
-
-    get name(): Workspace['name'] {
-        return 'mock-workspace';
-    }
-
-    get workspaceFile(): Workspace['workspaceFile'] {
-        return undefined;
-    }
-
-    rootPath = undefined;
-    isTrusted = true;
-    textDocuments = [];
-    notebookDocuments = [];
-
-    __mockConfig = createMockWorkspaceConfiguration(this.jest);
-
-    applyEdit = this.jest.fn();
-    asRelativePath = this.jest.fn((a) => a?.toString());
-    createFileSystemWatcher = this.jest.fn();
-    findFiles = this.jest.fn();
-    getConfiguration = this.jest.fn((...args: Parameters<Workspace['getConfiguration']>) =>
-        this.__mockConfig.__getConfiguration(...args),
-    );
-    getWorkspaceFolder = this.jest.fn((uri) => getWorkspaceFolder(uri, this.workspaceFolders || []));
-    onDidSaveTextDocument = this.jest.fn();
-    openTextDocument = openTextDocument;
-    openNotebookDocument = this.jest.fn();
-    onDidChangeConfiguration = this.jest.fn();
-    onDidChangeNotebookDocument = this.jest.fn();
-    onDidChangeTextDocument = this.jest.fn();
-    onDidChangeWorkspaceFolders = this.jest.fn();
-    onDidCloseNotebookDocument = this.jest.fn();
-    onDidCloseTextDocument = this.jest.fn();
-    onDidCreateFiles = this.jest.fn();
-    onDidDeleteFiles = this.jest.fn();
-    onDidGrantWorkspaceTrust = this.jest.fn();
-    onDidOpenNotebookDocument = this.jest.fn();
-    onDidOpenTextDocument = this.jest.fn();
-    onDidRenameFiles = this.jest.fn();
-    onDidSaveNotebookDocument = this.jest.fn();
-    onWillCreateFiles = this.jest.fn();
-    onWillDeleteFiles = this.jest.fn();
-    onWillRenameFiles = this.jest.fn();
-    onWillSaveNotebookDocument = this.jest.fn();
-    onWillSaveTextDocument = this.jest.fn();
-    registerFileSystemProvider = this.jest.fn();
-    registerNotebookSerializer = this.jest.fn();
-    registerTaskProvider = this.jest.fn();
-    registerTextDocumentContentProvider = this.jest.fn();
-    saveAll = this.jest.fn();
-    updateWorkspaceFolders = this.jest.fn();
-}
-
-export function createWorkspace(jest: TestFramework): MockWorkspace {
-    const workspace = new MockWorkspace(jest);
+    const workspace = new MockWorkspace();
     return workspace;
 }
+
+export type MockWorkspace = ReturnType<typeof createWorkspace>;
 
 interface OpenTextDocumentOptions {
     language?: string;

--- a/test-packages/vitest-integration/tsconfig.json
+++ b/test-packages/vitest-integration/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node16",
+    "extends": "@tsconfig/node18",
     "compilerOptions": {
         "tsBuildInfoFile": "./dist/compile.tsbuildInfo",
         "composite": true,

--- a/tsconfig.core.json
+++ b/tsconfig.core.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"display": "Jest Mock for VS Code Typescript Config",
-	"extends": "@tsconfig/node16/tsconfig.json",
+	"extends": "@tsconfig/node18/tsconfig.json",
 	"compilerOptions": {
 		"declaration": true,
 		"declarationMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"display": "Jest Mock for VS Code Typescript Config",
-	"extends": "@tsconfig/node16/tsconfig.json",
+	"extends": "@tsconfig/node18/tsconfig.json",
     "compilerOptions": {
     },
     "files": [],


### PR DESCRIPTION
BREAKING!
It is now necessary to use:
- `createWorkspace` instead of `new MockWorkspace`
- `createMockTabGroups` instead of `new MockTabGroups`
- `createMockTextEditor` instead of `new MockTextEditor`
