### PR TITLE
fix: Export `createMockTextEditor`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ export {
     createMockFileSystem,
     createMockFileSystemProvider,
     createMockWorkspaceConfiguration,
+    createMockTextEditor,
+    createWindow,
+    createWorkspace,
 } from './vscode';
 export type { MockWorkspaceConfigurationData } from './vscode';
 export { createVSCodeMock } from './vscode-mock';

--- a/src/vscode/index.ts
+++ b/src/vscode/index.ts
@@ -14,7 +14,8 @@ export { createMockFileSystem, createMockFileSystemProvider } from './fs';
 export * from './uri';
 export { MockWorkspace, Workspace, createWorkspace } from './workspace';
 
-export { MockTextEditor } from './TextEditor';
+export type { MockTextEditor } from './TextEditor';
+export { createMockTextEditor } from './TextEditor';
 export { TypeHierarchyItem } from './TypeHierarchyItem';
 export { Languages, createLanguages } from './languages';
 export { Window, createWindow } from './window';

--- a/test-packages/vitest-integration/src/sample.workspace.test.ts
+++ b/test-packages/vitest-integration/src/sample.workspace.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { Uri, workspace, type WorkspaceFolder } from 'vscode';
+import { Uri, workspace, type WorkspaceFolder, window } from 'vscode';
 
 vi.mock('vscode');
 
+const testFileUri = Uri.file(__filename);
 const rootUri = Uri.file(__dirname);
 const workspaceFolder1: WorkspaceFolder = {
     uri: Uri.joinPath(rootUri, 'Folder1'),
@@ -16,7 +17,7 @@ const workspaceFolder2: WorkspaceFolder = {
     index: 1,
 };
 
-describe('workspace', () => {
+describe('vscode.workspace', () => {
     afterEach(() => {
         vi.resetAllMocks();
     });
@@ -31,5 +32,25 @@ describe('workspace', () => {
         expect(workspace.workspaceFolders).toEqual([workspaceFolder1, workspaceFolder2]);
         expect(workspace.getWorkspaceFolder(uri)).toEqual(workspaceFolder1);
         expect(workspace.getWorkspaceFolder(uri2)).toEqual(workspaceFolder2);
+    });
+
+    test('openTextDocument', async () => {
+        const uri = testFileUri;
+        const doc = await workspace.openTextDocument(uri);
+        expect(doc.uri).toEqual(uri);
+        expect(doc.getText()).toContain("vi.mock('vscode');");
+    });
+});
+
+describe('vscode.window', () => {
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    test('showTextDocument', async () => {
+        const uri = testFileUri;
+        const doc = await workspace.openTextDocument(uri);
+        const editor = await window.showTextDocument(doc);
+        expect(editor.document).toBe(doc);
     });
 });


### PR DESCRIPTION
Sometimes it is necessary to have a TextEditor instance.