### PR TITLE
fix: `TextDocument.lineAt` properties

### DIFF
--- a/src/vscode/TextDocument.test.ts
+++ b/src/vscode/TextDocument.test.ts
@@ -71,6 +71,28 @@ describe('Validate TextDocument', () => {
         MockTextDocument.setContents(doc, content());
         expect(() => doc.save()).toThrow('Method not implemented.');
     });
+
+    test('lineAt', async () => {
+        const doc = createDoc();
+        
+        const line1 = doc.lineAt(1)
+        expect(line1.lineNumber).toEqual(1)
+        expect(line1.text).toEqual('Line 1')
+        expect(line1.firstNonWhitespaceCharacterIndex).toEqual(0)
+        expect(line1.isEmptyOrWhitespace).toEqual(false)
+
+        const line3 = doc.lineAt(3)
+        expect(line3.lineNumber).toEqual(3)
+        expect(line3.text).toEqual('')
+        expect(line3.firstNonWhitespaceCharacterIndex).toEqual(0)
+        expect(line3.isEmptyOrWhitespace).toEqual(true)
+
+        const line4 = doc.lineAt(4)
+        expect(line4.lineNumber).toEqual(4)
+        expect(line4.text).toEqual('  Line 4')
+        expect(line4.firstNonWhitespaceCharacterIndex).toEqual(2)
+        expect(line4.isEmptyOrWhitespace).toEqual(false)
+    });
 });
 
 function r(lineA: number, rowA: number, lineB: number, rowB: number): vscode.Range {

--- a/src/vscode/TextDocument.ts
+++ b/src/vscode/TextDocument.ts
@@ -46,13 +46,14 @@ export class MockTextDocument implements vscode.TextDocument {
         const lineNumber = typeof line === 'number' ? line : line.line;
         const fullLineText = this._lines[lineNumber];
         const text = fullLineText.replace(/\r?\n/, '');
+        const firstNonWhitespaceCharacterIndex = /^(\s*)/.exec(text)![1].length
         return {
             lineNumber,
             text,
             range: new mocked.Range(lineNumber, 0, lineNumber, text.length),
-            firstNonWhitespaceCharacterIndex: 0,
+            firstNonWhitespaceCharacterIndex,
             rangeIncludingLineBreak: new mocked.Range(lineNumber, 0, lineNumber, fullLineText.length),
-            isEmptyOrWhitespace: !!text.replace(/\s+/, ''),
+            isEmptyOrWhitespace: firstNonWhitespaceCharacterIndex === text.length,
         };
     }
 

--- a/src/vscode/TextDocument.ts
+++ b/src/vscode/TextDocument.ts
@@ -46,6 +46,10 @@ export class MockTextDocument implements vscode.TextDocument {
         const lineNumber = typeof line === 'number' ? line : line.line;
         const fullLineText = this._lines[lineNumber];
         const text = fullLineText.replace(/\r?\n/, '');
+        /**
+         * See: https://github.com/microsoft/vscode/blob/56222f3441914d033791e7e7a09b99423864751b/src/vs/workbench/api/common/extHostDocumentData.ts#L284-L291
+         */
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const firstNonWhitespaceCharacterIndex = /^(\s*)/.exec(text)![1].length
         return {
             lineNumber,


### PR DESCRIPTION
Fixes incorrect mocks of

  - `firstNonWhitespaceCharacterIndex`
  - `isEmptyOrWhitespace`

Fixes #564